### PR TITLE
Properly Handle Custom Http Endpoints

### DIFF
--- a/src/arize_otel/_register.py
+++ b/src/arize_otel/_register.py
@@ -133,12 +133,12 @@ def register_otel(
 
 
 def should_use_http(
-    endpoint: Endpoints,
+    endpoint: Union[str, Endpoints,
 ) -> bool:
     return endpoint in (
         Endpoints.LOCAL_PHOENIX_HTTP,
         Endpoints.HOSTED_PHOENIX,
-    )
+    ) or (isinstance(endpoint, str) and endpoint.startswith("http"))
 
 
 def validate_for_arize(space_id: str, space_key: str, api_key: str, model_id: str, project_name: str) -> None:


### PR DESCRIPTION
In the current version, `should_use_http` only returns `true` iff the endpoint url is in the `Endpoints` enum.
The `register_otel` function, however, accepts custom hosts as a string:

```
EndpointsType = Union[str, List[str], Endpoints, List[Endpoints]]

def register_otel(
    endpoints: EndpointsType,
```

So, if you call `register_otel` with an endpoint that is not in the `Endpoints` enum, (say, `http://localhost:7000`), then `should_use_http` will return `false`, even if the user intends to send things over http.

This pull request adjusts `should_use_http` to consider strings as input types.