### PR TITLE
[CLOSED - Wrong Fix] Add Python 3.14 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = ["src/arize"]
 name = "arize-otel"
 description = "Helper package for OTEL setup to send traces to Arize & Phoenix"
 readme = "README.md"
-requires-python = ">=3.8, <3.14"
+requires-python = ">=3.8, <3.15"
 license = { text = "BSD" }
 keywords = [
     "Observability",
@@ -38,6 +38,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Intended Audience :: Developers",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
## Summary
- Update `requires-python` constraint from `<3.14` to `<3.15` to include Python 3.14
- Add `Programming Language :: Python :: 3.14` classifier

This fixes the CI failures on `py310-ci-openllmetry-latest` and `py314-ci-openllmetry-latest` by allowing the package to be installed on Python 3.14.

## Test plan
- [ ] Verify CI passes on py314-ci-openllmetry-latest
- [ ] Verify CI passes on py310-ci-openllmetry-latest

Slack thread: https://arizeai.slack.com/archives/C07BPEE39FU/p1774895871757159?thread_ts=1774895517.271359&cid=C07BPEE39FU

https://claude.ai/code/session_01SFByQtG6gJhFXqHz2BKwzg